### PR TITLE
Fix bug when course doesn't have start_at

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,8 +79,11 @@ def main():
             course for course in courses if course.id in config.WHITELIST_CANVAS_ID]
     try:
         for course in courses:
-            delta = -(datetime.strptime(
-                course.start_at, r'%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None) - datetime.now()).days
+            if course.start_at:
+                delta = -(datetime.strptime(
+                    course.start_at, r'%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None) - datetime.now()).days
+            else:
+                delta = 0
             if course.id in config.IGNORED_CANVAS_ID:
                 print(
                     f"{Fore.CYAN}Explicitly Ignored Course: {course.course_code}{Style.RESET_ALL}")


### PR DESCRIPTION
When a course doesn't have the `start_at` property, a `TypeError` as follows is raised when trying to parse the date.
```
Traceback (most recent call last):
  File "canvas_grab/main.py", line 433, in <module>
    main()
  File "canvas_grab/main.py", line 82, in main
    delta = -(datetime.strptime(
TypeError: strptime() argument 1 must be str, not None
```
A proposed fix is included in the pull request.