### PR TITLE
code: fix snapshot on Windows

### DIFF
--- a/canvas_grab/snapshot/on_disk_snapshot.py
+++ b/canvas_grab/snapshot/on_disk_snapshot.py
@@ -13,7 +13,7 @@ class OnDiskSnapshot(Snapshot):
         for item in base.rglob('*'):
             if item.is_file() and not item.name.startswith('.'):
                 stat = item.stat()
-                self.snapshot[str(item.relative_to(base))] = SnapshotFile(
+                self.snapshot[item.relative_to(base).as_posix()] = SnapshotFile(
                     item.name, stat.st_size, int(stat.st_mtime))
         return self.snapshot
 


### PR DESCRIPTION
在Windows下将Path对象转换为str时，路径中的分隔符默认为反斜杠r"\\"，与从canvas上获取的文件路径不一致，导致文件名比对不一致，脚本误判所有文件在本地不存在，从而重新下载所有文件
在canvas_grab\snapshot\on_disk_snapshot.py第16行使用.as_posix函数可以将路径中的r"\\"转化为r"/"
