### PR TITLE
code: add argument support

### DIFF
--- a/canvas_grab/__main__.py
+++ b/canvas_grab/__main__.py
@@ -19,24 +19,25 @@ def get_options():
             f'You are using version {canvas_grab.__version__}. If you have any questions, please file an issue at {colored("https://github.com/skyzh/canvas_grab/issues", "blue")}')
         print(
             f'You may review {colored("README.md", "green")} and {colored("LICENSE", "green")} shipped with this release')
-        print(f'You may run this code with argument {colored(f"-h","cyan")} for command line usage')
+        print(
+            f'You may run this code with argument {colored(f"-h","cyan")} for command line usage')
         print('--------------------')
 
     # Argument Parser initiation
     parser = argparse.ArgumentParser(
         description='Grab all files on Canvas LMS to local directory.')
-    
+
     # Interactive
     interactive_group = parser.add_mutually_exclusive_group()
     interactive_group.add_argument("-i", "--interactive", dest="interactive", action="store_true",
                                    default=True, help="Set the program to run in interactive mode (default action)")
     interactive_group.add_argument("-I", "--non-interactive", "--no-input", dest="interactive", action="store_false", default=True,
                                    help="Set the program to run in non-interactive mode. This can be used to exit immediately in case of profile corruption without getting stuck with the input.")
-    
+
     # Reconfiguration
     parser.add_argument("-r", "--reconfigure", "--configure", dest="reconfigure", help="Reconfigure the tool.",
                         action="store_true")
-    
+
     # Location Specification
     parser.add_argument("-o", "--download-folder", "--output",
                         dest="download", help="Set the download folder.")
@@ -49,8 +50,8 @@ def get_options():
     #                 action="store_true")
     parser.add_argument("--version", action="version",
                         version=canvas_grab.__version__)
-    parser.add_argument("-k","--keep-version","--no-update",dest="noupdate",action="store_true",
-                                   default=False, help="Skip update checking. This will be helpful without a stable network connection and prevent reconfiguration.")
+    parser.add_argument("-k", "--keep-version", "--no-update", dest="noupdate", action="store_true",
+                        default=False, help="Skip update checking. This will be helpful without a stable network connection and prevent reconfiguration.")
 
     args = parser.parse_args()
 
@@ -83,7 +84,7 @@ def get_options():
     if args.download:
         config.download_folder = args.download
 
-    return args.interactive, args.noupdate,config
+    return args.interactive, args.noupdate, config
 
 
 def main():
@@ -142,7 +143,7 @@ def main():
         transfer = canvas_grab.transfer.Transfer()
         transfer.transfer(
             on_disk_path, f'{config.download_folder}/_canvas_grab_archive', plans)
-    
+
     if not noupdate:
         canvas_grab.version.check_latest_version()
 

--- a/canvas_grab/__main__.py
+++ b/canvas_grab/__main__.py
@@ -9,45 +9,91 @@ from canvasapi.exceptions import ResourceDoesNotExist
 import sys
 
 
-def request_reconfigure():
-    if len(sys.argv) >= 2:
-        if sys.argv[1] == 'configure':
-            return True
-    return False
+def get_options():
+    import argparse
 
+    def greeting():
+        # First, welcome our users
+        print("Thank you for using canvas_grab!")
+        print(
+            f'You are using version {canvas_grab.__version__}. If you have any questions, please file an issue at {colored("https://github.com/skyzh/canvas_grab/issues", "blue")}')
+        print(
+            f'You may review {colored("README.md", "green")} and {colored("LICENSE", "green")} shipped with this release')
+        print(f'You may run this code with argument {colored(f"-h","cyan")} for command line usage')
+        print('--------------------')
 
-def main():
-    init()
+    # Argument Parser initiation
+    parser = argparse.ArgumentParser(
+        description='Grab all files on Canvas LMS to local directory.')
+    
+    # Interactive
+    interactive_group = parser.add_mutually_exclusive_group()
+    interactive_group.add_argument("-i", "--interactive", dest="interactive", action="store_true",
+                                   default=True, help="Set the program to run in interactive mode (default action)")
+    interactive_group.add_argument("-I", "--non-interactive", "--no-input", dest="interactive", action="store_false", default=True,
+                                   help="Set the program to run in non-interactive mode. This can be used to exit immediately in case of profile corruption without getting stuck with the input.")
+    
+    # Reconfiguration
+    parser.add_argument("-r", "--reconfigure", "--configure", dest="reconfigure", help="Reconfigure the tool.",
+                        action="store_true")
+    
+    # Location Specification
+    parser.add_argument("-o", "--download-folder", "--output",
+                        dest="download", help="Set the download folder.")
+    parser.add_argument("-c", "--config-file", dest="config_file", default="config.toml",
+                        help="Specify the configuration file. The configurations are loaded in this order: arguments, file specified here, and the default config file config.toml.")
 
-    # First, welcome our users
-    print("Thank you for using canvas_grab!")
-    print(
-        f'You are using version {canvas_grab.__version__}. If you have any questions, please file an issue at {colored("https://github.com/skyzh/canvas_grab/issues", "blue")}')
-    print(
-        f'You may review {colored("README.md", "green")} and {colored("LICENSE", "green")} shipped with this release')
-    print('--------------------')
+    # Generic Options
+    # TODO quiet mode
+    # parser.add_argument("-q", "--quiet",dest="quiet", help="Start the program in quiet mode. Only errors will be printed.",
+    #                 action="store_true")
+    parser.add_argument("--version", action="version",
+                        version=canvas_grab.__version__)
+    parser.add_argument("-k","--keep-version","--no-update",dest="noupdate",action="store_true",
+                                   default=False, help="Skip update checking. This will be helpful without a stable network connection and prevent reconfiguration.")
 
-    # Then, load config and start setup wizard
+    args = parser.parse_args()
 
-    config_file = Path('config.toml')
+    # TODO quiet mode
+    greeting()
+
+    config_file = Path(args.config_file)
     config = canvas_grab.config.Config()
-    require_reconfigure = False
-    if config_file.exists():
+    config_fail = False
+    if (not args.reconfigure) and config_file.exists():
         try:
             config.from_config(toml.loads(
                 config_file.read_text(encoding='utf8')))
         except KeyError as e:
             print(
                 f'It seems that you have upgraded canvas_grab. Please reconfigure. ({colored(e, "red")} not found)')
-            require_reconfigure = True
-    if not config_file.exists() or request_reconfigure() or require_reconfigure:
+            config_fail = True
+    if config_fail or args.reconfigure or not config_file.exists():
+        if not args.interactive:
+            print(
+                "configuration file corrupted or not exist, and non interactive flag is set. Quit immediately.")
+            exit(-1)
         try:
             config.interact()
         except KeyboardInterrupt:
             print("User canceled the configuration process")
             return
-        Path('config.toml').write_text(
+        Path(args.config_file).write_text(
             toml.dumps(config.to_config()), encoding='utf8')
+    if args.download:
+        config.download_folder = args.download
+
+    return args.interactive, args.noupdate,config
+
+
+def main():
+    init()
+    # Welcome users, and load configurations.
+    try:
+        interactive, noupdate, config = get_options()
+    except TypeError:
+        # User canceled the configuration process
+        return
 
     # Finally, log in and start synchronize
     canvas = config.endpoint.login()
@@ -96,8 +142,9 @@ def main():
         transfer = canvas_grab.transfer.Transfer()
         transfer.transfer(
             on_disk_path, f'{config.download_folder}/_canvas_grab_archive', plans)
-
-    canvas_grab.version.check_latest_version()
+    
+    if not noupdate:
+        canvas_grab.version.check_latest_version()
 
 
 if __name__ == '__main__':

--- a/canvas_grab/__main__.py
+++ b/canvas_grab/__main__.py
@@ -89,7 +89,7 @@ def get_options():
         except KeyboardInterrupt:
             print("User canceled the configuration process")
             return
-        Path(config_file).write_text(
+        config_file.write_text(
             toml.dumps(config.to_config()), encoding='utf8')
     if args.download:
         config.download_folder = args.download

--- a/canvas_grab/__main__.py
+++ b/canvas_grab/__main__.py
@@ -24,34 +24,44 @@ def get_options():
         print('--------------------')
 
     # Argument Parser initiation
+
     parser = argparse.ArgumentParser(
-        description='Grab all files on Canvas LMS to local directory.')
+        description='Grab all files on Canvas LMS to local directory.',
+        epilog="Configuration file variables specified with program arguments will override the "
+        "original settings at runtime, but will not be written to the original configuration file. "
+        "If you specify a configuration file with the --config-file argument when you configure it, "
+        "it will be overwritten with the new content.")
 
     # Interactive
     interactive_group = parser.add_mutually_exclusive_group()
     interactive_group.add_argument("-i", "--interactive", dest="interactive", action="store_true",
-                                   default=True, help="Set the program to run in interactive mode (default action)")
-    interactive_group.add_argument("-I", "--non-interactive", "--no-input", dest="interactive", action="store_false", default=True,
-                                   help="Set the program to run in non-interactive mode. This can be used to exit immediately in case of profile corruption without getting stuck with the input.")
+                                   default=True,
+                                   help="Set the program to run in interactive mode (default action)")
+    interactive_group.add_argument("-I", "--non-interactive", "--no-input", dest="interactive",
+                                   action="store_false", default=True,
+                                   help="Set the program to run in non-interactive mode. This can be "
+                                   "used to exit immediately in case of profile corruption without "
+                                   "getting stuck with the input.")
 
     # Reconfiguration
-    parser.add_argument("-r", "--reconfigure", "--configure", dest="reconfigure", help="Reconfigure the tool.",
-                        action="store_true")
+    parser.add_argument("-r", "--reconfigure", "--configure", dest="reconfigure",
+                        help="Reconfigure the tool.", action="store_true")
 
     # Location Specification
     parser.add_argument("-o", "--download-folder", "--output",
-                        dest="download", help="Set the download folder.")
+                        dest="download", help="Specify alternative download folder.")
     parser.add_argument("-c", "--config-file", dest="config_file", default="config.toml",
-                        help="Specify the configuration file. The configurations are loaded in this order: arguments, file specified here, and the default config file config.toml.")
+                        help="Specify alternative configuration file.")
 
     # Generic Options
     # TODO quiet mode
-    # parser.add_argument("-q", "--quiet",dest="quiet", help="Start the program in quiet mode. Only errors will be printed.",
-    #                 action="store_true")
+    # parser.add_argument("-q", "--quiet", dest="quiet", help="Start the program in quiet mode. "
+    #                     "Only errors will be printed.", action="store_true")
     parser.add_argument("--version", action="version",
                         version=canvas_grab.__version__)
     parser.add_argument("-k", "--keep-version", "--no-update", dest="noupdate", action="store_true",
-                        default=False, help="Skip update checking. This will be helpful without a stable network connection and prevent reconfiguration.")
+                        default=False, help="Skip update checking. This will be helpful without "
+                        "a stable network connection and prevent reconfiguration.")
 
     args = parser.parse_args()
 
@@ -79,7 +89,7 @@ def get_options():
         except KeyboardInterrupt:
             print("User canceled the configuration process")
             return
-        Path(args.config_file).write_text(
+        Path(config_file).write_text(
             toml.dumps(config.to_config()), encoding='utf8')
     if args.download:
         config.download_folder = args.download

--- a/configure.ps1
+++ b/configure.ps1
@@ -1,4 +1,4 @@
 #!/usr/bin/pwsh
 $ErrorActionPreference = "Stop"
 
-./canvas_grab.ps1 configure
+./canvas_grab.ps1 --configure

--- a/configure.sh
+++ b/configure.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./canvas_grab.sh configure
+./canvas_grab.sh --configure


### PR DESCRIPTION
Add POSIX like arguments support for non-interactive use.
```
usage: main.py [-h] [-i | -I] [-r] [-o DOWNLOAD] [-c CONFIG_FILE] [--version] [-k]

Grab all files on Canvas LMS to local directory.

optional arguments:
  -h, --help            show this help message and exit
  -i, --interactive     Set the program to run in interactive mode (default action)
  -I, --non-interactive, --no-input
                        Set the program to run in non-interactive mode. This can be used to exit
                        immediately in case of profile corruption without getting stuck with the input.
  -r, --reconfigure, --configure
                        Reconfigure the tool.
  -o DOWNLOAD, --download-folder DOWNLOAD, --output DOWNLOAD
                        Set the download folder.
  -c CONFIG_FILE, --config-file CONFIG_FILE
                        Specify the configuration file. The configurations are loaded in this order:
                        arguments, file specified here, and the default config file config.toml.
  --version             show program's version number and exit
  -k, --keep-version, --no-update
                        Skip update checking. This will be helpful without a stable network connection
                        and prevent reconfiguration.
```
This will help automation with multiple profiles.