### PR TITLE
release 2.0.5

### DIFF
--- a/canvas_grab/version.py
+++ b/canvas_grab/version.py
@@ -4,7 +4,7 @@ from packaging import version as ver_parser
 from termcolor import colored
 
 GITHUB_RELEASE_URL = "https://api.github.com/repos/skyzh/canvas_grab/releases/latest"
-VERSION = "2.0.5-alpha"
+VERSION = "2.0.5"
 
 
 def check_latest_version():


### PR DESCRIPTION
Could you add a simple "pause" ,or (at least windows) users may not be able to see message about the newest version.
(I try to add a line of "pause” at the end of *.ps1 ,which works well.)
