### PR TITLE
code: fix Transfer.clean_tree

### DIFF
--- a/canvas_grab/transfer.py
+++ b/canvas_grab/transfer.py
@@ -78,11 +78,18 @@ class Transfer(object):
 
         self.clean_tree(base_path)
 
-    def clean_tree(self, path):
+    def clean_tree(self, path) -> bool:
+        """Remove empty folder recursively.
+        Returns True if folder is deleted.
+        """
         path = Path(path)
-        children = list(path.glob('*'))
-        for child in children:
-            if child.is_dir():
-                self.clean_tree(child)
-        if not children:
+        if not path.is_dir():
+            return True
+        children = cleaned_children = list(path.glob('*'))
+        for child_idx in reversed(range(len(children))):
+            if children[child_idx].is_dir() and self.clean_tree(children[child_idx]):
+                del cleaned_children[child_idx]
+        if not cleaned_children:
             path.rmdir()
+            return True
+        return False


### PR DESCRIPTION
Original Transfer.clean_tree has two problem:
1. Will not remove a folder when all children are deleted.
2. Not checking if path exists, will cause error when no file was uploaded to canvas.
```
(13/13) Course 形势与政策 (ID: *****)
  Download to TH020-形势与政策
  Updating 0 objects (0 remote objects -> 0 local objects)
Traceback (most recent call last):
  File "[scriptdir]/main.py", line 6, in <module>
    canvas_grab.__main__.main()
  File "[scriptdir]/canvas_grab/__main__.py", line 158, in main
    transfer.transfer(
  File "[scriptdir]/canvas_grab/transfer.py", line 79, in transfer
    self.clean_tree(base_path)
  File "[scriptdir]/canvas_grab/transfer.py", line 88, in clean_tree
    path.rmdir()
  File "/usr/lib/python3.9/pathlib.py", line 1352, in rmdir
    self._accessor.rmdir(self)
FileNotFoundError: [Errno 2] No such file or directory: '[downdir]/TH020-形势与政策'
```